### PR TITLE
4th-axis fixes and improvements

### DIFF
--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -392,15 +392,7 @@ class ObjectOp(PathOp.ObjectOp):
         self.axialRapid = 360 / safeCircum * self.horizRapid # pylint: disable=attribute-defined-outside-init
 
         # Initiate depthparams and calculate operation heights for rotational operation
-        finish_step = obj.FinishDepth.Value if hasattr(obj, "FinishDepth") else 0.0
-        self.depthparams = PathUtils.depth_params( # pylint: disable=attribute-defined-outside-init
-            clearance_height=obj.ClearanceHeight.Value,
-            safe_height=obj.SafeHeight.Value,
-            start_depth=obj.StartDepth.Value,
-            step_down=obj.StepDown.Value,
-            z_finish_step=finish_step,
-            final_depth=obj.FinalDepth.Value,
-            user_depths=None)
+        self.depthparams = self._customDepthParams(obj, obj.StartDepth.Value, obj.FinalDepth.Value)
 
         # Set start point
         if PathOp.FeatureStartPoint & self.opFeatures(obj) and obj.UseStartPoint:
@@ -446,15 +438,7 @@ class ObjectOp(PathOp.ObjectOp):
             else:
                 nextAxis = 'L'
 
-            finish_step = obj.FinishDepth.Value if hasattr(obj, "FinishDepth") else 0.0
-            self.depthparams = PathUtils.depth_params( # pylint: disable=attribute-defined-outside-init
-                clearance_height=obj.ClearanceHeight.Value,
-                safe_height=obj.SafeHeight.Value,
-                start_depth=strDep,  # obj.StartDepth.Value,
-                step_down=obj.StepDown.Value,
-                z_finish_step=finish_step,
-                final_depth=finDep,  # obj.FinalDepth.Value,
-                user_depths=None)
+            self.depthparams = self._customDepthParams(obj, strDep, finDep)
 
             try:
                 if self.profileEdgesIsOpen is True:
@@ -475,22 +459,16 @@ class ObjectOp(PathOp.ObjectOp):
                         axisOfRot = 'A'
                     elif axis == 'Y':
                         axisOfRot = 'B'
-                        # Reverse angle temporarily to match model. Error in FreeCAD render of B axis rotations
-                        if obj.B_AxisErrorOverride is True:
-                            angle = -1 * angle
                     elif axis == 'Z':
                         axisOfRot = 'C'
                     else:
                         axisOfRot = 'A'
-                    
                     # Rotate Model to correct angle
-                    ppCmds.insert(0, Path.Command('G0', {axisOfRot: angle, 'F': self.axialFeed}))
-                    #ppCmds.insert(0, Path.Command('N100', {}))
+                    ppCmds.insert(0, Path.Command('G0', {axisOfRot: angle, 'F': self.axialRapid}))
 
                     # Raise cutter to safe depth and return index to starting position
-                    #ppCmds.append(Path.Command('N200', {}))
                     ppCmds.append(Path.Command('G0', {'Z': obj.SafeHeight.Value, 'F': self.vertRapid}))
-                    if 'L' != nextAxis:
+                    if axis != nextAxis:
                         ppCmds.append(Path.Command('G0', {axisOfRot: 0.0, 'F': self.axialRapid}))
                 # Eif
 
@@ -762,7 +740,7 @@ class ObjectOp(PathOp.ObjectOp):
             xAx = 'xAxCyl'
             yAx = 'yAxCyl'
             # zAx = 'zAxCyl'
-            FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup", "visualAxis")
+            VA = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup", "visualAxis")
             if FreeCAD.GuiUp:
                 FreeCADGui.ActiveDocument.getObject('visualAxis').Visibility = False
             vaGrp = FreeCAD.ActiveDocument.getObject("visualAxis")
@@ -794,6 +772,7 @@ class ObjectOp(PathOp.ObjectOp):
                 cylGui.Transparency = 85
                 cylGui.Visibility = False
             vaGrp.addObject(cyl)
+            VA.purgeTouched()
 
     def useTempJobClones(self, cloneName):
         '''useTempJobClones(cloneName)
@@ -809,6 +788,8 @@ class ObjectOp(PathOp.ObjectOp):
                     for cln in FreeCAD.ActiveDocument.getObject('rotJobClones').Group:
                         FreeCAD.ActiveDocument.removeObject(cln.Name)
                     FreeCAD.ActiveDocument.removeObject('rotJobClones')
+                else:
+                    FreeCAD.ActiveDocument.getObject('rotJobClones').purgeTouched()
         else:
             FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup", "rotJobClones")
             if FreeCAD.GuiUp:
@@ -918,7 +899,7 @@ class ObjectOp(PathOp.ObjectOp):
         obj.AttemptInverseAngle = False
         angle = -1 * angle
 
-        PathLog.info(translate("Path", "Rotated to inverse angle."))
+        PathLog.debug(translate("Path", "Rotated to inverse angle."))
         return (clnBase, clnStock, angle)
 
     def sortTuplesByIndex(self, TupleList, tagIdx):
@@ -961,3 +942,28 @@ class ObjectOp(PathOp.ObjectOp):
             return True
         else:
             return False
+
+    def isFaceUp(self, base, face):
+        up = face.extrude(FreeCAD.Vector(0.0, 0.0, 5.0))
+        dwn = face.extrude(FreeCAD.Vector(0.0, 0.0, -5.0))
+        upCmn = base.Shape.common(up)
+        dwnCmn = base.Shape.common(dwn)
+        if upCmn.Volume == 0.0:
+            return True
+        elif dwnCmn.Volume == 0.0:
+            return False
+        if dwnCmn.Volume > upCmn.Volume:
+            return True
+        return False
+
+    def _customDepthParams(self, obj, strDep, finDep):
+        finish_step = obj.FinishDepth.Value if hasattr(obj, "FinishDepth") else 0.0
+        cdp = PathUtils.depth_params(
+            clearance_height=obj.ClearanceHeight.Value,
+            safe_height=obj.SafeHeight.Value,
+            start_depth=strDep,
+            step_down=obj.StepDown.Value,
+            z_finish_step=finish_step,
+            final_depth=finDep,
+            user_depths=None)
+        return cdp

--- a/src/Mod/Path/PathScripts/PathDrilling.py
+++ b/src/Mod/Path/PathScripts/PathDrilling.py
@@ -45,11 +45,9 @@ __url__ = "http://www.freecadweb.org"
 __doc__ = "Path Drilling operation."
 __contributors__ = "russ4262 (Russell Johnson), IMBack!"
 __created__ = "2014"
-__scriptVersion__ = "1c testing"
-__lastModified__ = "2019-06-25 14:49 CST"
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
-#PathLog.trackModule(PathLog.thisModule())
+# PathLog.trackModule(PathLog.thisModule())
 
 
 # Qt translation handling
@@ -84,8 +82,6 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
             obj.addProperty('App::PropertyBool', 'ReverseDirection', 'Rotation', QtCore.QT_TRANSLATE_NOOP('App::Property', 'Reverse direction of pocket operation.'))
         if not hasattr(obj, 'InverseAngle'):
             obj.addProperty('App::PropertyBool', 'InverseAngle', 'Rotation', QtCore.QT_TRANSLATE_NOOP('App::Property', 'Inverse the angle. Example: -22.5 -> 22.5 degrees.'))
-        if not hasattr(obj, 'B_AxisErrorOverride'):
-            obj.addProperty('App::PropertyBool', 'B_AxisErrorOverride', 'Rotation', QtCore.QT_TRANSLATE_NOOP('App::Property', 'Match B rotations to model (error in FreeCAD rendering).'))
         if not hasattr(obj, 'AttemptInverseAngle'):
             obj.addProperty('App::PropertyBool', 'AttemptInverseAngle', 'Rotation', QtCore.QT_TRANSLATE_NOOP('App::Property', 'Attempt the inverse angle for face access if original rotation fails.'))
 
@@ -109,7 +105,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
         holes = PathUtils.sort_jobs(holes, ['x', 'y'])
         self.commandlist.append(Path.Command('G90'))
         self.commandlist.append(Path.Command(obj.ReturnLevel))
- 
+
         for p in holes:
             cmd = "G81"
             cmdParams = {}
@@ -135,9 +131,6 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
                     axisOfRot = 'A'
                 elif axis == 'Y':
                     axisOfRot = 'B'
-                    # Reverse angle temporarily to match model. Error in FreeCAD render of B axis rotations
-                    if obj.B_AxisErrorOverride is True:
-                        angle = -1 * angle
                 elif axis == 'Z':
                     axisOfRot = 'C'
                 else:
@@ -159,15 +152,13 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
                 self.commandlist.append(Path.Command('G0', {axisOfRot: angle, 'F': self.axialRapid}))
                 self.commandlist.append(Path.Command('G0', {'X': p['x'], 'Y': p['y'], 'F': self.horizRapid}))
                 self.commandlist.append(Path.Command('G1', {'Z': p['stkTop'], 'F': self.vertFeed}))
-            
+
             # Perform canned drilling cycle
             self.commandlist.append(Path.Command(cmd, params))
-            
-            # cancel canned drilling cycle
+
+            # Cancel canned drilling cycle
             self.commandlist.append(Path.Command('G80'))
             self.commandlist.append(Path.Command('G0', {'Z': obj.SafeHeight.Value}))
-            
-
 
             # shift axis and angle values
             if obj.EnableRotation != 'Off':
@@ -178,30 +169,28 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
             self.commandlist.append(Path.Command('G0', {'Z': obj.SafeHeight.Value, 'F': self.vertRapid}))
             self.commandlist.append(Path.Command('G0', {lastAxis: 0.0, 'F': self.axialRapid}))
 
-
     def opSetDefaultValues(self, obj, job):
         '''opSetDefaultValues(obj, job) ... set default value for RetractHeight'''
-        
+
         parentJob = PathUtils.findParentJob(obj)
 
         if hasattr(parentJob.SetupSheet, 'RetractHeight'):
             obj.RetractHeight = parentJob.SetupSheet.RetractHeight
         elif self.applyExpression(obj, 'RetractHeight', 'OpStartDepth+1mm'):
             obj.RetractHeight = 10
-                    
+
         if hasattr(parentJob.SetupSheet, 'PeckDepth'):
             obj.PeckDepth = parentJob.SetupSheet.PeckDepth
         elif self.applyExpression(obj, 'PeckDepth', 'OpToolDiameter*0.75'):
             obj.PeckDepth = 1
-            
+
         if hasattr(parentJob.SetupSheet, 'DwellTime'):
             obj.DwellTime = parentJob.SetupSheet.DwellTime
         else:
             obj.DwellTime = 1
-                    
+
         obj.ReverseDirection = False
         obj.InverseAngle = False
-        obj.B_AxisErrorOverride = False
         obj.AttemptInverseAngle = False
 
         # Initial setting for EnableRotation is taken from Job SetupSheet
@@ -224,7 +213,6 @@ def SetupProperties():
     setup.append("EnableRotation")
     setup.append("ReverseDirection")
     setup.append("InverseAngle")
-    setup.append("B_AxisErrorOverride")
     setup.append("AttemptInverseAngle")
     return setup
 

--- a/src/Mod/Path/PathScripts/PathPocketBase.py
+++ b/src/Mod/Path/PathScripts/PathPocketBase.py
@@ -34,11 +34,13 @@ __url__ = "http://www.freecadweb.org"
 __doc__ = "Base class and implementation for Path pocket operations."
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
-#PathLog.trackModule(PathLog.thisModule())
+# PathLog.trackModule(PathLog.thisModule())
+
 
 # Qt translation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
+
 
 class ObjectPocket(PathAreaOp.ObjectOp):
     '''Base class for proxy objects of all pocket operations.'''
@@ -129,6 +131,7 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             params['sort_mode'] = 3
             params['threshold'] = self.radius * 2
         return params
+
 
 def SetupProperties():
     setup = []

--- a/src/Mod/Path/PathScripts/PathProfileBase.py
+++ b/src/Mod/Path/PathScripts/PathProfileBase.py
@@ -34,7 +34,8 @@ __url__ = "http://www.freecadweb.org"
 __doc__ = "Base class and implementation for Path profile operations."
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
-#PathLog.trackModule(PathLog.thisModule())
+# PathLog.trackModule(PathLog.thisModule())
+
 
 # Qt translation handling
 def translate(context, text, disambig=None):
@@ -75,9 +76,22 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             else:
                 obj.setEditorMode('MiterLimit', 2)
 
+        self.extraOpOnChanged(obj, prop)
+
+    def extraOpOnChanged(self, obj, prop):
+        '''otherOpOnChanged(obj, porp) ... overwrite to process onChange() events.
+        Can safely be overwritten by subclasses.'''
+        pass # pylint: disable=unnecessary-pass
+
+    def setOpEditorProperties(self, obj):
+        '''setOpEditorProperties(obj, porp) ... overwrite to process operation specific changes to properties.
+        Can safely be overwritten by subclasses.'''
+        pass # pylint: disable=unnecessary-pass
+
     def areaOpOnDocumentRestored(self, obj):
         for prop in ['UseComp', 'JoinType']:
             self.areaOpOnChanged(obj, prop)
+        self.setOpEditorProperties(obj)
 
     def areaOpAreaParams(self, obj, isHole):
         '''areaOpAreaParams(obj, isHole) ... returns dictionary with area parameters.
@@ -140,6 +154,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         obj.UseComp = True
         obj.JoinType = "Round"
         obj.MiterLimit = 0.1
+
 
 def SetupProperties():
     setup = []


### PR DESCRIPTION
Fix rotational orientation of pockets.  Need to apply same fix to ProfileFaces.
Fix final depth issue based upon error in rotational orientation fixed here.
Add property, `LimitDepthToFace` to facilitate easier pockets and face profiling on rotational-enabled operations.
Hide rotational support properties when operations do not use rotation.
Remove unnecessary property, `B_AxisErrorOverride`, and delete dead code that used it.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
